### PR TITLE
Update gcloud and add missing connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The following connections are available:
 - `dns_connection`
 - `pubsub_connection`
 - `resource_manager_connection`
-- `search_connection`
 - `storage_connection`
 
 ## Background

--- a/README.md
+++ b/README.md
@@ -14,31 +14,43 @@ Thread-safe client functionality for gcloud-python via requests.
 pip install --upgrade gcloud_requests
 ```
 
-**Note** that at this time, only `gcloud==0.7.0` on Python 2.7 is
+**Note** that at this time, only `gcloud==0.8.0` on Python 2.7 is
 officially supported.
 
 ## Usage
 
-The library provides a new connection that can be passed in to the
-`gcloud.datastore.Client` constructor.
-
-### Google Cloud Datastore
+The library provides new HTTP objects that can be passed in to the
+`gcloud.*.Client` constructors (per supported API module). For example,
+to use the connection class (with proper retrying implemented) for
+Google Cloud Datastore:
 
 ```
 from gcloud import datastore
-from gcloud_requests import connection
+from gcloud_requests.connection import datastore_connection
 
-client = datastore.Client(connection=connection.datastore_connection)
+client = datastore.Client(http=datastore_connection.http)
 client.query(kind="EntityKind").fetch()
 ```
 
-### Google Cloud Storage
+and for Google Cloud Storage:
 
 ```
-client = gcloud.storage.Client(project="my-project")
-client._connection = connection.storage_connection
+from gcloud import storage
+from gcloud_requests.connection import storage_connection
+
+client = gcloud.storage.Client(http=storage_connection.http, project="my-project")
 bucket = client.get_bucket("my-bucket")
 ```
+
+The following connections are available:
+
+- `bigquery_connection`
+- `datastore_connection`
+- `dns_connection`
+- `pubsub_connection`
+- `resource_manager_connection`
+- `search_connection`
+- `storage_connection`
 
 ## Background
 

--- a/gcloud_requests/connection.py
+++ b/gcloud_requests/connection.py
@@ -1,7 +1,21 @@
 import gcloud.credentials
 
-from .requests_connection import DatastoreConnection, StorageConnection
+from .requests_connection import (
+    BigQueryConnection,
+    DatastoreConnection,
+    DNSConnection,
+    PubSubConnection,
+    ResourceManagerConnection,
+    SearchConnection,
+    StorageConnection
+)
 
 credentials = gcloud.credentials.get_credentials()
+
+bigquery_connection = BigQueryConnection(credentials=credentials)
 datastore_connection = DatastoreConnection(credentials=credentials)
+dns_connection = DNSConnection(credentials=credentials)
+pubsub_connection = PubSubConnection(credentials=credentials)
+resource_manager_connection = ResourceManagerConnection(credentials=credentials)
+search_connection = SearchConnection(credentials=credentials)
 storage_connection = StorageConnection(credentials=credentials)

--- a/gcloud_requests/connection.py
+++ b/gcloud_requests/connection.py
@@ -6,7 +6,6 @@ from .requests_connection import (
     DNSConnection,
     PubSubConnection,
     ResourceManagerConnection,
-    SearchConnection,
     StorageConnection
 )
 
@@ -17,5 +16,4 @@ datastore_connection = DatastoreConnection(credentials=credentials)
 dns_connection = DNSConnection(credentials=credentials)
 pubsub_connection = PubSubConnection(credentials=credentials)
 resource_manager_connection = ResourceManagerConnection(credentials=credentials)
-search_connection = SearchConnection(credentials=credentials)
 storage_connection = StorageConnection(credentials=credentials)

--- a/gcloud_requests/requests_connection.py
+++ b/gcloud_requests/requests_connection.py
@@ -9,7 +9,6 @@ from gcloud.datastore.connection import Connection as GCloudDatastoreConnection
 from gcloud.dns.connection import Connection as GCloudDNSConnection
 from gcloud.pubsub.connection import Connection as GCloudPubSubConnection
 from gcloud.resource_manager.connection import Connection as GCloudResourceManagerConnection
-from gcloud.search.connection import Connection as GCloudSearchConnection
 from gcloud.storage.connection import Connection as GCloudStorageConnection
 
 logger = logging.getLogger(__file__)
@@ -197,12 +196,6 @@ class ResourceManagerConnection(
         GCloudResourceManagerConnection,
         RequestsConnectionMixin):
     "A Resource Manager-compatible connection."
-
-
-class SearchConnection(
-        GCloudSearchConnection,
-        RequestsConnectionMixin):
-    "A Search-compatible connection."
 
 
 class StorageConnection(

--- a/gcloud_requests/requests_connection.py
+++ b/gcloud_requests/requests_connection.py
@@ -2,10 +2,15 @@ import logging
 import requests
 import time
 
-from gcloud.datastore.connection import Connection as GCloudDatastoreConnection
-from gcloud.connection import Connection as GCloudConnection
-from gcloud.storage.connection import Connection as GCloudStorageConnection
 from threading import local
+from gcloud.connection import Connection as GCloudConnection
+from gcloud.bigquery.connection import Connection as GCloudBigQueryConnection
+from gcloud.datastore.connection import Connection as GCloudDatastoreConnection
+from gcloud.dns.connection import Connection as GCloudDNSConnection
+from gcloud.pubsub.connection import Connection as GCloudPubSubConnection
+from gcloud.resource_manager.connection import Connection as GCloudResourceManagerConnection
+from gcloud.search.connection import Connection as GCloudSearchConnection
+from gcloud.storage.connection import Connection as GCloudStorageConnection
 
 logger = logging.getLogger(__file__)
 _state = local()
@@ -162,12 +167,42 @@ class RequestsConnectionMixin(GCloudConnection):
         return self._http
 
 
+class BigQueryConnection(
+        GCloudBigQueryConnection,
+        RequestsConnectionMixin):
+    "A BigQuery-compatible connection."
+
+
 class DatastoreConnection(
         GCloudDatastoreConnection,
         RequestsConnectionMixin):
-    "A datastore-compatible connection."
+    "A Datastore-compatible connection."
 
     REQUESTS_PROXY_CLASS = DatastoreRequestsProxy
+
+
+class DNSConnection(
+        GCloudDNSConnection,
+        RequestsConnectionMixin):
+    "A DNS-compatible connection."
+
+
+class PubSubConnection(
+        GCloudPubSubConnection,
+        RequestsConnectionMixin):
+    "A PubSub-compatible connection."
+
+
+class ResourceManagerConnection(
+        GCloudResourceManagerConnection,
+        RequestsConnectionMixin):
+    "A Resource Manager-compatible connection."
+
+
+class SearchConnection(
+        GCloudSearchConnection,
+        RequestsConnectionMixin):
+    "A Search-compatible connection."
 
 
 class StorageConnection(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gcloud==0.7.0
-requests==2.7.0
+gcloud==0.8.0
+requests==2.9.0
 certifi==2015.09.06.2

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
     license="MIT",
     packages=["gcloud_requests"],
     install_requires=[
-        "gcloud==0.7.0",
-        "requests==2.7.0",
+        "gcloud==0.8.0",
+        "requests==2.9.0",
         "certifi==2015.09.06.2"
     ],
     classifiers=[

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -3,13 +3,13 @@ import multiprocessing
 import time
 
 from gcloud import datastore
-from gcloud_requests import connection
+from gcloud_requests.connection import datastore_connection
 
 from threading import Thread
 
 logging.basicConfig(level=logging.DEBUG)
 
-client = datastore.Client(connection=connection.datastore_connection)
+client = datastore.Client(http=datastore_connection.http)
 ns = "gcloud-requests-{}".format(time.time())
 
 forms = client.query(kind="Form", namespace=ns).fetch()


### PR DESCRIPTION
This bumps `gcloud` to 0.8.0 and `requests` to 2.9.0. With the `gcloud` bump, some minor interface changes were needed (`Client` takes an `http` now rather than a `connection`).

This also expands the surface of the library to include the other publicly-available APIs supported by `gcloud`.

Tests are available but I'm working on spinning up a system test environment in a new project first.

ping @lillian-lemmer @Bogdanp 