### PR TITLE
Update gcloud to 0.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gcloud==0.9.0
+gcloud==0.10.1
 requests>=2.9.0,<3.0
 certifi==2015.09.06.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=["gcloud_requests"],
     install_requires=[
-        "gcloud==0.9.0",
+        "gcloud==0.10.1",
         "requests>=2.9.0,<3.0",
         "certifi==2015.09.06.2"
     ],


### PR DESCRIPTION
Zooming through the 0.10.0 release to 0.10.1 which allows pinning a newer version of `oauth2client` and brings some bugfixes. Have not observed any breaking changes.

Release notes: https://github.com/GoogleCloudPlatform/gcloud-python/releases

cc @Bogdanp 