### PR TITLE
Pin gcloud to 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Thread-safe client functionality for gcloud-python via requests.
 pip install --upgrade gcloud_requests
 ```
 
-**Note** that at this time, only `gcloud==0.10.1` on Python 2.7 is
+**Note** that at this time, only `gcloud==0.11.0` on Python 2.7 is
 officially supported.
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gcloud==0.10.1
+gcloud==0.11.0
 requests>=2.9.0,<3.0
 certifi==2015.09.06.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=["gcloud_requests"],
     install_requires=[
-        "gcloud==0.10.1",
+        "gcloud==0.11.0",
         "requests>=2.9.0,<3.0",
         "certifi==2015.09.06.2"
     ],


### PR DESCRIPTION
This should avoid further issues with the bad release of `protobuf`, though the release has been hidden.

Ref: GoogleCloudPlatform/gcloud-python#1570 and google/protobuf#1294

cc @Bogdanp 