### PR TITLE
Update to gcloud 0.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ python:
   - "2.7"
 before_install:
   - openssl aes-256-cbc -K $encrypted_84a2848b3b48_key -iv $encrypted_84a2848b3b48_iv -in tests/travisci-gcloud_requests.json.enc -out travisci-gcloud_requests.json -d
+  - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+  - echo "deb http://packages.cloud.google.com/apt precise main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y google-cloud-sdk
   - export GOOGLE_APPLICATION_CREDENTIALS=travisci-gcloud_requests.json
-  - export DATASTORE_HOST=http://localhost:8080
-  - export DATASTORE_DATASET=gcloud
   - mkdir ./datastore
-  - curl -o gcd.zip http://storage.googleapis.com/gcd/tools/$GCD_VERSION.zip
-  - unzip gcd.zip
-  - ./$GCD_VERSION/gcd.sh create -d gcloud ./datastore
-  - ./$GCD_VERSION/gcd.sh start --port=8080 ./datastore &
+  - gcloud beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud
 install: "pip install -r requirements.txt"
-script: "env PYTHONPATH=. python tests/test_datastore.py"
+script: "env PYTHONPATH=. DATASTORE_HOST=http://localhost:8080/datastore DATASTORE_DATASET=gcloud python tests/test_datastore.py"
 addons:
   code_climate:
     repo_token: 1ae0e51788ad23c845e353566a8b245c4c2929035709105e2b8407d6ae2e2b51

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ python:
   - "2.7"
 before_install:
   - openssl aes-256-cbc -K $encrypted_84a2848b3b48_key -iv $encrypted_84a2848b3b48_iv -in tests/travisci-gcloud_requests.json.enc -out travisci-gcloud_requests.json -d
-  - curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-  - echo "deb http://packages.cloud.google.com/apt precise main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y google-cloud-sdk
+  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-103.0.0-linux-x86_64.tar.gz -O /tmp/gcloud.tar.gz
+  - tar -xvf /tmp/gcloud.tar.gz
+  - export PATH=$PATH:$PWD/google-cloud-sdk/bin
   - export GOOGLE_APPLICATION_CREDENTIALS=travisci-gcloud_requests.json
   - mkdir ./datastore
   - gcloud beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=$PATH:$PWD/google-cloud-sdk/bin
   - export GOOGLE_APPLICATION_CREDENTIALS=travisci-gcloud_requests.json
   - mkdir ./datastore
-  - gcloud -q beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud
+  - gcloud -q beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud &
 install: "pip install -r requirements.txt"
 script: "env PYTHONPATH=. DATASTORE_HOST=http://localhost:8080/datastore DATASTORE_DATASET=gcloud python tests/test_datastore.py"
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export PATH=$PATH:$PWD/google-cloud-sdk/bin
   - export GOOGLE_APPLICATION_CREDENTIALS=travisci-gcloud_requests.json
   - mkdir ./datastore
-  - gcloud beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud
+  - gcloud -q beta emulators datastore start --data-dir=./datastore --consistency 1.0 --host-port localhost:8080 --project=gcloud
 install: "pip install -r requirements.txt"
 script: "env PYTHONPATH=. DATASTORE_HOST=http://localhost:8080/datastore DATASTORE_DATASET=gcloud python tests/test_datastore.py"
 addons:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Thread-safe client functionality for gcloud-python via requests.
 pip install --upgrade gcloud_requests
 ```
 
-**Note** that at this time, only `gcloud==0.11.0` on Python 2.7 is
+**Note** that at this time, only `gcloud==0.12.0` on Python 2.7 is
 officially supported.
 
 ## Usage

--- a/gcloud_requests/connection.py
+++ b/gcloud_requests/connection.py
@@ -4,6 +4,7 @@ from .requests_connection import (
     BigQueryRequestsProxy,
     DatastoreRequestsProxy,
     DNSRequestsProxy,
+    LoggingRequestsProxy,
     PubSubRequestsProxy,
     StorageRequestsProxy
 )
@@ -13,5 +14,6 @@ credentials = gcloud.credentials.get_credentials()
 bigquery_http = BigQueryRequestsProxy(credentials)
 datastore_http = DatastoreRequestsProxy(credentials)
 dns_http = DNSRequestsProxy(credentials)
+logging_http = LoggingRequestsProxy(credentials)
 pubsub_http = PubSubRequestsProxy(credentials)
 storage_http = StorageRequestsProxy(credentials)

--- a/gcloud_requests/requests_connection.py
+++ b/gcloud_requests/requests_connection.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from gcloud.bigquery.connection import Connection as GCloudBigQueryConnection
 from gcloud.datastore.connection import Connection as GCloudDatastoreConnection
 from gcloud.dns.connection import Connection as GCloudDNSConnection
+from gcloud.logging.connection import Connection as GCloudLoggingConnection
 from gcloud.pubsub.connection import Connection as GCloudPubSubConnection
 from gcloud.storage.connection import Connection as GCloudStorageConnection
 from threading import local
@@ -190,6 +191,10 @@ class DatastoreRequestsProxy(RequestsProxy):
 
 class DNSRequestsProxy(RequestsProxy):
     SCOPE = GCloudDNSConnection.SCOPE
+
+
+class LoggingRequestsProxy(RequestsProxy):
+    SCOPE = GCloudLoggingConnection.SCOPE
 
 
 class PubSubRequestsProxy(RequestsProxy):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gcloud==0.11.0
+gcloud==0.12.0
 requests>=2.9.0,<3.0
 certifi==2015.09.06.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=["gcloud_requests"],
     install_requires=[
-        "gcloud==0.11.0",
+        "gcloud==0.12.0",
         "requests>=2.9.0,<3.0",
         "certifi==2015.09.06.2"
     ],


### PR DESCRIPTION
Effectively switches Cloud Datastore to v1beta3. Also adds connection adapter for the Cloud Logging API. No update for the now-supported BigTable API as it is GRPC-only.

Also updates build process to use `gcloud` instead of `gcd.sh`.