### PR TITLE
Pass a retry count for read errors

### DIFF
--- a/gcloud_requests/requests_connection.py
+++ b/gcloud_requests/requests_connection.py
@@ -64,7 +64,7 @@ class RequestsProxy(object):
         # socket errors, etc.
         session = getattr(_state, "session", None)
         if session is None:
-            retry_config = Retry(5, read=True)
+            retry_config = Retry(5, read=5)
             session = _state.session = requests.Session()
             adapter = _state.adapter = requests.adapters.HTTPAdapter(
                 max_retries=retry_config


### PR DESCRIPTION
I mistakenly thought that the `read` parameter just toggled on a broader set of exceptions; in fact it takes the number of read retries to allot the request. See the [docs on `Retry`](https://github.com/shazow/urllib3/blob/master/urllib3/util/retry.py#L33).