### PR TITLE
Use fully qualified urllib3 Retry import

### DIFF
--- a/gcloud_requests/requests_connection.py
+++ b/gcloud_requests/requests_connection.py
@@ -9,7 +9,7 @@ from gcloud.logging.connection import Connection as GCloudLoggingConnection
 from gcloud.pubsub.connection import Connection as GCloudPubSubConnection
 from gcloud.storage.connection import Connection as GCloudStorageConnection
 from google.rpc import status_pb2
-from requests.packages.urllib3 import Retry
+from requests.packages.urllib3.util.retry import Retry
 from threading import local
 
 from . import logger


### PR DESCRIPTION
See shazow/urllib3#567 for what is happening here; this manifests as given in the original issue (`TypeError: unsupported operand type(s) for -=: 'Retry' and 'int'`).