### PR TITLE
Upgrade to latest google cloud libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libtool
   - openssl aes-256-cbc -K $encrypted_84a2848b3b48_key -iv $encrypted_84a2848b3b48_iv -in tests/leadpages-8687295e9cc6.json.enc -out leadpages-8687295e9cc6.json -d
-  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-141.0.0-linux-x86_64.tar.gz -O /tmp/gcloud.tar.gz
+  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-229.0.0-linux-x86_64.tar.gz -O /tmp/gcloud.tar.gz
   - tar -xvf /tmp/gcloud.tar.gz -C $HOME
   - export PATH=$HOME/google-cloud-sdk/bin:$PATH
   - export GOOGLE_APPLICATION_CREDENTIALS="leadpages-8687295e9cc6.json"
-  - gcloud -q components install beta gcd-emulator
+  - gcloud -q components install beta cloud-datastore-emulator
   - gcloud -q beta emulators datastore start --no-store-on-disk --consistency 1.0 &
   - sleep 15 && eval $(gcloud beta emulators datastore env-init)
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
+dist: xenial
+sudo: required
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libtool

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Thread-safe client functionality for `google-cloud-{datastore,storage}` via requ
 pip install --upgrade gcloud_requests
 ```
 
-**Note** that at this time, only `google-cloud-datastore==1.0.0` is
-officially supported.
-
 ## Usage
 
 Google Cloud Datastore:

--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -22,22 +22,9 @@ _credentials_watcher = CredentialsWatcher()
 atexit.register(_credentials_watcher.stop)
 
 
-class ResponseProxy(requests.structures.CaseInsensitiveDict):
-    def __init__(self, response):
-        super(ResponseProxy, self).__init__()
-        self.response = response
-        self.update(response.headers)
-        self.update(status=str(self.status))
-
-    @property
-    def status(self):
-        return self.response.status_code
-
-
 class RequestsProxy(object):
     """Wraps a ``requests`` library :class:`.Session` instance and
-    exposes a `request` method that is compatible with the
-    ``httplib2`` `request` method.
+    exposes a compatible `request` method.
     """
 
     SCOPE = None
@@ -77,31 +64,30 @@ class RequestsProxy(object):
     def __del__(self):
         _credentials_watcher.unwatch(self.credentials)
 
-    def request(self, uri, method="GET", body=None, headers=None, redirections=5, connection_type=None, retries=0, refresh_attempts=0):   # noqa
+    def request(self, method, url, data=None, headers=None, retries=0, refresh_attempts=0, **kwargs):
         session = self._get_session()
         headers = headers.copy() if headers is not None else {}
         auth_request = AuthRequest(session=session)
         retry_auth = partial(
             self.request,
-            uri=uri, method=method,
-            body=body, headers=headers,
-            redirections=redirections,
-            connection_type=connection_type,
+            url=url, method=method,
+            data=data, headers=headers,
             refresh_attempts=refresh_attempts + 1,
             retries=0,  # Retries intentionally get reset to 0.
+            **kwargs
         )
 
         try:
-            self.credentials.before_request(auth_request, method, uri, headers)
+            self.credentials.before_request(auth_request, method, url, headers)
         except RefreshError:
             if refresh_attempts < _max_refresh_attempts:
                 return retry_auth()
             raise
 
         response = session.request(
-            method, uri, data=body, headers=headers,
-            allow_redirects=redirections > 0,
+            method, url, data=data, headers=headers,
             timeout=self.TIMEOUT_CONFIG,
+            **kwargs
         )
         if response.status_code in _refresh_status_codes and refresh_attempts < _max_refresh_attempts:
             self.logger.info(
@@ -119,13 +105,12 @@ class RequestsProxy(object):
         elif response.status_code >= 400:
             response = self._handle_response_error(
                 response, retries,
-                uri=uri, method=method,
-                body=body, headers=headers,
-                redirections=redirections,
-                connection_type=connection_type
+                url=url, method=method,
+                data=data, headers=headers,
+                **kwargs
             )
 
-        return ResponseProxy(response), response.content
+        return response
 
     def _get_session(self):
         # Ensure we use one connection-pooling session per thread and
@@ -145,7 +130,7 @@ class RequestsProxy(object):
         return session
 
     def _handle_response_error(self, response, retries, **kwargs):
-        """Provides a way for each connection wrapper to handle error
+        r"""Provides a way for each connection wrapper to handle error
         responses.
 
         Parameters:
@@ -173,8 +158,8 @@ class RequestsProxy(object):
 
         retries += 1
         self.logger.warning("Retrying failed request. Attempt %d/%d.", retries, max_retries)
-        response_proxy, _ = self.request(retries=retries, **kwargs)
-        return response_proxy.response
+
+        return self.request(retries=retries, **kwargs)
 
     def _convert_response_to_error(self, response):
         """Subclasses may override this method in order to influence

--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -53,7 +53,7 @@ class RequestsProxy(object):
     )
 
     #: The number of connections to pool per Session.
-    CONNETION_POOL_SIZE = 32
+    CONNECTION_POOL_SIZE = 32
 
     # A mapping from numeric Google RPC error codes to known error
     # code strings.
@@ -137,8 +137,8 @@ class RequestsProxy(object):
             session = _state.session = requests.Session()
             adapter = _state.adapter = requests.adapters.HTTPAdapter(
                 max_retries=self.RETRY_CONFIG,
-                pool_connections=self.CONNETION_POOL_SIZE,
-                pool_maxsize=self.CONNETION_POOL_SIZE,
+                pool_connections=self.CONNECTION_POOL_SIZE,
+                pool_maxsize=self.CONNECTION_POOL_SIZE,
             )
             session.mount("http://", adapter)
             session.mount("https://", adapter)

--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -3,12 +3,13 @@ import logging
 import requests
 import time
 
+import google.auth
+
 from functools import partial
 from google.rpc import status_pb2
 from google.auth.credentials import with_scopes_if_required
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request as AuthRequest
-from google.cloud.credentials import get_credentials
 from requests.packages.urllib3.util.retry import Retry
 from threading import local
 
@@ -66,7 +67,7 @@ class RequestsProxy(object):
 
     def __init__(self, credentials=None, logger=None):
         if credentials is None:
-            credentials = get_credentials()
+            credentials = google.auth.default()[0]
             credentials = with_scopes_if_required(credentials, self.SCOPE)
 
         self.logger = logger or logging.getLogger(type(self).__name__)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 # Supported libs
-google-cloud-datastore>=1.1,<1.2
+google-cloud-datastore>=1.1,<2.0
 google-cloud-storage>=1.1.1,<2
 
 # Testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,14 @@
 -r requirements.txt
 
 # Supported libs
-google-cloud-datastore>=1.1,<2.0
-google-cloud-storage>=1.1.1,<2
+# grpc is necessary for datastore.
+# Because we pull in google-cloud-core from requirements.txt without grpc
+# extras specified, when we install google-cloud-datastore, which has
+# google-api-core[grpc] specified, pip fails to see the missing extras
+# dependency.
+google-api-core[grpc]
+google-cloud-datastore>=1.6,<2.0
+google-cloud-storage>=1.1.1,<2.0
 
 # Testing
 futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-auth>=1.0.1,<2.0
-google-cloud-core>=0.29.1,<0.30
+google-cloud-core>=0.25,<0.30dev
 requests>=2.9,<3
 six>=1.10.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-auth>=1.0.1,<2.0
-google-cloud-core>=0.24,<0.25
+google-cloud-core>=0.29.1,<0.30
 requests>=2.9,<3
 six>=1.10.0,<2.0

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ]
 )

--- a/tests/test_datastore_proxy.py
+++ b/tests/test_datastore_proxy.py
@@ -37,7 +37,7 @@ def test_datastore_proxy_retries_retriable_json_errors(datastore_proxy, error_da
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = datastore_proxy.request("http://example.com")
+        datastore_proxy.request("GET", "http://example.com")
 
         # I expect the endpoint to have been called some number of times
         assert sum(calls) == expected_tries
@@ -67,7 +67,7 @@ def test_datastore_proxy_retries_retriable_protobuf_errors(datastore_proxy, erro
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = datastore_proxy.request("http://example.com")
+        datastore_proxy.request("GET", "http://example.com")
 
         # I expect the endpoint to have been called some number of times
         assert sum(calls) == expected_tries
@@ -90,7 +90,7 @@ def test_datastore_proxy_does_not_retry_invalid_json(datastore_proxy):
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = datastore_proxy.request("http://example.com")
+        datastore_proxy.request("GET", "http://example.com")
 
         # I expect the endpoint to have been called once
         assert sum(calls) == 1
@@ -112,10 +112,10 @@ def test_datastore_proxy_retries_on_502(datastore_proxy):
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = datastore_proxy.request("http://example.com")
+        response = datastore_proxy.request("GET", "http://example.com")
 
         # I expect to get back a 502
-        assert response.status == 502
+        assert response.status_code == 502
 
         # And the endpoint to have been called a total of 6 times
         assert sum(calls) == 6
@@ -142,7 +142,7 @@ def test_datastore_proxy_does_not_retry_aborted_statuses_while_in_transaction(da
 
         try:
             # Then make a request
-            response, _ = datastore_proxy.request("http://example.com")
+            datastore_proxy.request("GET", "http://example.com")
 
             # I expect the endpoint to only get called once
             assert sum(calls) == 1
@@ -184,8 +184,8 @@ def test_datastore_proxy_retries_token_refresh_errors(datastore_proxy):
 
     with HTTMock(downstream), HTTMock(refresh):
         # If I make a request
-        response, body = datastore_proxy.request("http://example.com")
+        response = datastore_proxy.request("GET", "http://example.com")
 
         # I expect it to succeed
-        assert response["status"] == "200"
-        assert body == b"{}"
+        assert response.status_code == 200
+        assert response.content == b"{}"

--- a/tests/test_pubsub_proxy.py
+++ b/tests/test_pubsub_proxy.py
@@ -28,7 +28,7 @@ def test_pubsub_proxy_retries_retriable_json_errors(pubsub_proxy, error_data, ex
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = pubsub_proxy.request("http://example.com")
+        pubsub_proxy.request("GET", "http://example.com")
 
         # I expect the endpoint to have been called some number of times
         assert sum(calls) == expected_tries

--- a/tests/test_storage_proxy.py
+++ b/tests/test_storage_proxy.py
@@ -28,7 +28,10 @@ def test_storage_proxy_retries_retriable_json_errors(storage_proxy, code, expect
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = storage_proxy.request("http://example.com")
+        response = storage_proxy.request("GET", "http://example.com")
+
+        # I expect to get back a 500
+        assert response.status_code == 500
 
         # I expect the endpoint to have been called some number of times
         assert sum(calls) == expected_tries
@@ -51,10 +54,10 @@ def test_storage_proxy_retries_on_502(storage_proxy):
 
     with HTTMock(request_handler):
         # If I make a request
-        response, _ = storage_proxy.request("http://example.com")
+        response = storage_proxy.request("GET", "http://example.com")
 
         # I expect to get back a 502
-        assert response.status == 503
+        assert response.status_code == 503
 
         # And the endpoint to have been called a total of 6 times
         assert sum(calls) == 6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{27,35,36}-cpython
+  py{27,35,36,37}-cpython
   flake8
 
 [testenv]


### PR DESCRIPTION
This updates the API to work with newer gcloud libs.

The main change is `httplib2` has been replaced with `requests`.

Small changes include:
* Updating the call to fetch credentials
* Adding Python 3.7 support
* Upgrading the gcloud SDK for newer datastore emulator

I tested this with older versions of the datastore library and found the API compatible just one minor release back from current, `1.6`.

The `google-cloud-core` library looks to be compatible from `0.25` on up.  Given the `0.x` release I've kept the ceiling at the current minor version.  I figure we can always test and publish when new releases are made.

Due to the breaking API changes I think we should cut this as `2.x`.  I've published this on our internal PyPI as `2.0.0a1.dev1` for testing.