### PR TITLE
Widen google-cloud-core pin to include v1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 google-auth>=1.0.1,<2.0
-google-cloud-core>=0.25,<0.30dev
+google-cloud-core>=0.25,<2.0
 requests>=2.9,<3
 six>=1.10.0,<2.0


### PR DESCRIPTION
Not much changed: https://github.com/googleapis/google-cloud-python/blob/master/core/CHANGELOG.md

Mostly requires a newer api-core (`1.11`) instead of `1.0`.