### PR TITLE
Fix calls to request() with timeout kwarg

### DIFF
--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -84,11 +84,10 @@ class RequestsProxy(object):
                 return retry_auth()
             raise
 
-        response = session.request(
-            method, url, data=data, headers=headers,
-            timeout=self.TIMEOUT_CONFIG,
-            **kwargs
-        )
+        # Do not allow multiple timeout kwargs.
+        kwargs["timeout"] = self.TIMEOUT_CONFIG
+
+        response = session.request(method, url, data=data, headers=headers, **kwargs)
         if response.status_code in _refresh_status_codes and refresh_attempts < _max_refresh_attempts:
             self.logger.info(
                 "Refreshing credentials due to a %s response. Attempt %s/%s.",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ google-cloud-storage>=1.1.1,<2.0
 # Testing
 futures
 httmock
+mock
 pytest>=3
 pytest-cov
 tox

--- a/tests/test_storage_proxy.py
+++ b/tests/test_storage_proxy.py
@@ -1,7 +1,10 @@
 import json
+
 import pytest
+import requests
 
 from httmock import HTTMock, urlmatch
+from mock import Mock, patch
 
 
 @pytest.mark.parametrize("code,expected_tries", [
@@ -41,7 +44,7 @@ def test_storage_proxy_retries_on_502(storage_proxy):
     # Given that I have a GCS Proxy and a call database
     calls = []
 
-    # And I've mocked the requests library to return 502s on requests
+    # And I've mocked the requests library to return 503s on requests
     # to example.com
     @urlmatch(netloc=".*example.com")
     def request_handler(netloc, request):
@@ -56,8 +59,30 @@ def test_storage_proxy_retries_on_502(storage_proxy):
         # If I make a request
         response = storage_proxy.request("GET", "http://example.com")
 
-        # I expect to get back a 502
+        # I expect to get back a 503
         assert response.status_code == 503
 
         # And the endpoint to have been called a total of 6 times
         assert sum(calls) == 6
+
+
+def test_storage_proxy_overrides_timeout_in_kwargs(storage_proxy):
+    # Given a mocked requests session with a successful response
+    with patch("gcloud_requests.proxy.RequestsProxy._get_session") as mock_get_session:
+        mock_response = Mock(spec=requests.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.content = ""
+        mock_session = Mock(spec=requests.Session)
+        mock_session.request.return_value = mock_response
+        mock_get_session.return_value = mock_session
+
+        # If I make a request with a different timeout
+        timeout = (123, 123)
+        assert timeout != storage_proxy.TIMEOUT_CONFIG
+        response = storage_proxy.request("GET", "http://example.com", timeout=timeout)
+
+    # I expect a successful status code
+    assert response.status_code == 200
+    # And I expect the timeout to match the config instead of the provided kwarg
+    assert mock_session.request.call_args.kwargs["timeout"] == storage_proxy.TIMEOUT_CONFIG


### PR DESCRIPTION
The google-cloud-storage lib recently started providing a default
`timeout` kwarg to its requests, and this caused a clash with our
timeout kwarg.

This works around it by just overriding the timeout param in kwargs.