### PR TITLE
Fix CI tests for oauth2 refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libtool
   - openssl aes-256-cbc -K $encrypted_84a2848b3b48_key -iv $encrypted_84a2848b3b48_iv -in tests/leadpages-8687295e9cc6.json.enc -out leadpages-8687295e9cc6.json -d
-  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-229.0.0-linux-x86_64.tar.gz -O /tmp/gcloud.tar.gz
+  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-272.0.0-linux-x86_64.tar.gz -O /tmp/gcloud.tar.gz
   - tar -xvf /tmp/gcloud.tar.gz -C $HOME
   - export PATH=$HOME/google-cloud-sdk/bin:$PATH
   - export GOOGLE_APPLICATION_CREDENTIALS="leadpages-8687295e9cc6.json"


### PR DESCRIPTION
It looks like this commit introduced an error where google.oauth2
library now expects valid JSON:
googleapis/google-auth-library-python@eae1dcb

To work around it this just modifies the test to return valid JSON with
an error body.

Also, I noticed the URL has changed, so this expands the httmock matcher
to respond for both APIs.