### PR TITLE
Ignore TypeErrors during CredentialWatcher shutdown

### DIFF
--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -62,7 +62,13 @@ class RequestsProxy(object):
         _credentials_watcher.watch(credentials)
 
     def __del__(self):
-        _credentials_watcher.unwatch(self.credentials)
+        try:
+            _credentials_watcher.unwatch(self.credentials)
+        except TypeError:
+            # This can happen when the daemon thread shuts down and
+            # __del__() is implicitly ran. Crops up most commonly
+            # in test suites as 'NoneType' object is not callable.
+            pass
 
     def request(self, method, url, data=None, headers=None, retries=0, refresh_attempts=0, **kwargs):
         session = self._get_session()


### PR DESCRIPTION
Not sure this is the _best_ way to fix this, but it's quite a noisy thing across our API tests.  I don't have a test reproducing this, but try a `pip install -e ../gcloud_requests` and `pytest` at any of our API projects to see the fix.

The actual thing throwing the NoneType error is [here](https://github.com/LeadPages/gcloud_requests/blob/ba8adcc6c2025312519430f3206a26102d1876de/gcloud_requests/credentials_watcher.py#L76), inside `Condition.notify()`.  Inside that, `waiters_to_notify = _deque(_islice(all_waiters, n))`, at least in Python 3.6.8.

Anyways, it seems safe to bury this one.  I'm guessing this is due to `__del__` running after the condition, or thread, has been destroyed.  Felt worth leaving in as a best-effort cleanup, though.