### PR TITLE
add is_mtls workaround

### DIFF
--- a/gcloud_requests/proxy.py
+++ b/gcloud_requests/proxy.py
@@ -52,6 +52,11 @@ class RequestsProxy(object):
         14: "UNAVAILABLE",
     }
 
+    # Fix for GCS client setting ALLOW_AUTO_SWITCH_TO_MTLS_URL to True
+    # unless an api_endpoint client_option is set
+    # https://github.com/googleapis/python-cloud-core/pull/75/files
+    is_mtls = False
+
     def __init__(self, credentials=None, logger=None):
         if credentials is None:
             credentials = google.auth.default()[0]


### PR DESCRIPTION
From Greg's digging:
it seems this is based on the cloud core client adding mtls support, and now depending on an is_mtls property in the passed in client. I think ultimately this is actually a bug, as per their docs we should be able to pass in a requests.Session-compatible object, which that is not. 
Probably worth filing upstream, but in the mean time I think we can pave over the new problem by just adding is_mtls = False w/ a comment to https://github.com/googleapis/python-cloud-core/pull/75/files and the code.