### PR TITLE
Cloudbuild Pipeline for gcloud_requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ __pycache__
 /dist
 /gcloud_requests.egg-info
 /htmlcov
+cloudbuild_pypirc
+netrc
+pip.conf
+gcloud
+build
+dist

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,34 @@
-DOCKER != which docker
-MKDIR != which mkdir
-RM != which rm
+DOCKER ?= docker
+MKDIR ?= mkdir
+RM ?= rm
 
 PROJECT=gcloud-requests
 
 LATEST_SUPPORTED_PY_VERSION=3.11
 
 SUPPORTED_PY_VERSIONS=2.7 3.6 3.7 3.8 3.9 $(LATEST_SUPPORTED_PY_VERSION)
+
+# Determine platform flag (only needed for python 2.7)
+# grpcio HAS NO PRE_BUILT WHEELS FOR ARM64 FOR PYTHON 2, SO FORCE PLATFORM TO linuc/amd64
+# For grpcio We also need to rebuild from source with the alpine image, so for python 2.7, we dont use the full debian
+define PLATFORM_ARG
+$(if $(filter 2.7,$(PY_VERSION)),--platform=linux/amd64,)
+endef
+PY_IMAGE = python:$(PY_VERSION)-alpine
+ifeq ($(PY_VERSION),2.7)
+  PY_IMAGE = python:2.7
+endif
+# Addtionally, the python 2.7 debian image will need bash to work with runtests.sh and buildwheel.sh
+SHELL_CMD = sh
+ifeq ($(PY_VERSION),2.7)
+  SHELL_CMD = /bin/bash
+endif
+
+# NOT FULLY Mocked, setting project ID as lp-infra-lab
+GOOGLE_CLOUD_PROJECT ?= lp-infra-lab
+DATASTORE_PROJECT_ID ?= $(GOOGLE_CLOUD_PROJECT)
+DATASTORE_DATASET    ?= $(GOOGLE_CLOUD_PROJECT)
+GCLOUD_PROJECT       ?= $(GOOGLE_CLOUD_PROJECT)
 
 .PHONY: test ci-tests
 
@@ -23,12 +45,16 @@ ${HOME}/.config/gcloud/application_default_credentials.json:
 	gcloud auth application-default login
 
 run: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
-	$(DOCKER) run -it --rm=true --name=$(PROJECT)_python$(PY_VERSION) \
+	$(DOCKER) run $(PLATFORM_ARG) -it --rm=true --name=$(PROJECT)_python$(PY_VERSION) \
 	  -v $(CURDIR):/workspace \
 	  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
 	  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
-	  python:$(PY_VERSION)-alpine \
-	  /bin/sh -c "/workspace/ci/runtests.sh onlysetup; exec /bin/sh"
+	  -e DATASTORE_PROJECT_ID=$(DATASTORE_PROJECT_ID) \
+	  -e DATASTORE_DATASET=$(DATASTORE_DATASET) \
+	  -e GOOGLE_CLOUD_PROJECT=$(GOOGLE_CLOUD_PROJECT) \
+	  -e GCLOUD_PROJECT=$(GCLOUD_PROJECT) \
+	  $(PY_IMAGE) \
+	  $(SHELL_CMD) -c "/workspace/ci/runtests.sh onlysetup; exec /bin/sh"
 
 lint:
 	$(DOCKER) run --rm \
@@ -36,11 +62,15 @@ lint:
 	  python:3.11-alpine sh -c "pip install flake8 && flake8 /workspace/gcloud_requests /workspace/tests"
 
 test: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
-	$(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	$(DOCKER) run $(PLATFORM_ARG) -it --rm=true --name=$(PROJECT)_$@ \
 	  -v $(CURDIR):/workspace \
 	  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
 	  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
-	  python:$(PY_VERSION)-alpine sh /workspace/ci/runtests.sh
+	  -e DATASTORE_PROJECT_ID=$(DATASTORE_PROJECT_ID) \
+	  -e DATASTORE_DATASET=$(DATASTORE_DATASET) \
+	  -e GOOGLE_CLOUD_PROJECT=$(GOOGLE_CLOUD_PROJECT) \
+	  -e GCLOUD_PROJECT=$(GCLOUD_PROJECT) \
+	  $(PY_IMAGE) $(SHELL_CMD) /workspace/ci/runtests.sh
 
 ci-tests:
 	$(foreach pyversion, $(SUPPORTED_PY_VERSIONS), $(MAKE) PY_VERSION=$(pyversion) test;)
@@ -49,7 +79,7 @@ bdist_wheel: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application
 	# THIS WILL PUBLISH THE LIBRARY! HAVE YOU SET THE gcloud_requests/__init__.py versions TO A DEV VERSION???
 	@if [ x"$(BUILD_TYPE)" == x"release" ]; then \
 	  if grep __version__ gcloud_requests/__init__.py | grep -q '[0-9]*\.[0-9]*[\.\-]dev'; then \
-	    $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	    $(DOCKER) run $(PLATFORM_ARG) -it --rm=true --name=$(PROJECT)_$@ \
 	      -v $(CURDIR):/workspace \
 		  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
 		  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
@@ -59,7 +89,7 @@ bdist_wheel: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application
 	    echo "The __version__ in gcloud_requests/__init__.py does not contain  'dev' designator"; \
 	  fi \
 	else \
-	  $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	  $(DOCKER) run $(PLATFORM_ARG) -it --rm=true --name=$(PROJECT)_$@ \
 	    -v $(CURDIR):/workspace \
 		-v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
 		-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ DOCKER != which docker
 MKDIR != which mkdir
 RM != which rm
 
-PROJECT=gcloud_requests
+PROJECT=gcloud-requests
 
-SUPPORTED_PY_VERSIONS=2.7 3.6 3.7 3.8 3.9 3.11
+LATEST_SUPPORTED_PY_VERSION=3.11
+
+SUPPORTED_PY_VERSIONS=2.7 3.6 3.7 3.8 3.9 $(LATEST_SUPPORTED_PY_VERSION)
 
 .PHONY: test ci-tests
 
@@ -17,33 +19,47 @@ pip.conf:
 cloudbuild_pypirc:
 	cp ${HOME}/.pypirc cloudbuild_pypirc
 
-gcloud:
-	cp ${HOME}/.config/gcloud gcloud
+${HOME}/.config/gcloud/application_default_credentials.json:
+	gcloud auth application-default login
 
-test: netrc pip.conf cloudbuild_pypirc gcloud
+run: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
+	$(DOCKER) run -it --rm=true --name=$(PROJECT)_python$(PY_VERSION) \
+	  -v $(CURDIR):/workspace \
+	  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
+	  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
+	  python:$(PY_VERSION)-alpine \
+	  /bin/sh -c "/workspace/ci/runtests.sh onlysetup; exec /bin/sh"
+
+test: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
 	$(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
 	  -v $(CURDIR):/workspace \
+	  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
+	  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 	  python:$(PY_VERSION)-alpine sh /workspace/ci/runtests.sh
 
 ci-tests:
 	$(foreach pyversion, $(SUPPORTED_PY_VERSIONS), $(MAKE) PY_VERSION=$(pyversion) test;)
 
-bdist_wheel: netrc pip.conf cloudbuild_pypirc gcloud
+bdist_wheel: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
 	# THIS WILL PUBLISH THE LIBRARY! HAVE YOU SET THE gcloud_requests/__init__.py versions TO A DEV VERSION???
 	@if [ x"$(BUILD_TYPE)" == x"release" ]; then \
 	  if grep __version__ gcloud_requests/__init__.py | grep -q '[0-9]*\.[0-9]*[\.\-]dev'; then \
 	    $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
 	      -v $(CURDIR):/workspace \
+		  -v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
+		  -e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 	      --env BUILD_TYPE=$(BUILD_TYPE) \
-	      python:3.11-alpine /bin/sh /workspace/ci/buildwheel.sh; \
+	      python:$(LATEST_SUPPORTED_PY_VERSION)-alpine /bin/sh /workspace/ci/buildwheel.sh; \
 	  else \
 	    echo "The __version__ in gcloud_requests/__init__.py does not contain  'dev' designator"; \
 	  fi \
 	else \
 	  $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
 	    -v $(CURDIR):/workspace \
+		-v ${HOME}/.config/gcloud:/root/.config/gcloud:ro \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json \
 	    --env BUILD_TYPE=local \
-	    python:3.11-alpine /bin/sh /workspace/ci/buildwheel.sh; \
+	    python:$(LATEST_SUPPORTED_PY_VERSION)-alpine /bin/sh /workspace/ci/buildwheel.sh; \
 	fi
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+DOCKER != which docker
+MKDIR != which mkdir
+RM != which rm
+
+PROJECT=gcloud_requests
+
+SUPPORTED_PY_VERSIONS=2.7 3.6 3.7 3.8 3.9 3.11
+
+.PHONY: test ci-tests
+
+netrc:
+	cp ${HOME}/.netrc netrc
+
+pip.conf:
+	cp ${HOME}/.pip/pip.conf pip.conf
+
+cloudbuild_pypirc:
+	cp ${HOME}/.pypirc cloudbuild_pypirc
+
+gcloud:
+	cp ${HOME}/.config/gcloud gcloud
+
+test: netrc pip.conf cloudbuild_pypirc gcloud
+	$(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	  -v $(CURDIR):/workspace \
+	  python:$(PY_VERSION)-alpine sh /workspace/ci/runtests.sh
+
+ci-tests:
+	$(foreach pyversion, $(SUPPORTED_PY_VERSIONS), $(MAKE) PY_VERSION=$(pyversion) test;)
+
+bdist_wheel: netrc pip.conf cloudbuild_pypirc gcloud
+	# THIS WILL PUBLISH THE LIBRARY! HAVE YOU SET THE gcloud_requests/__init__.py versions TO A DEV VERSION???
+	@if [ x"$(BUILD_TYPE)" == x"release" ]; then \
+	  if grep __version__ gcloud_requests/__init__.py | grep -q '[0-9]*\.[0-9]*[\.\-]dev'; then \
+	    $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	      -v $(CURDIR):/workspace \
+	      --env BUILD_TYPE=$(BUILD_TYPE) \
+	      python:3.11-alpine /bin/sh /workspace/ci/buildwheel.sh; \
+	  else \
+	    echo "The __version__ in gcloud_requests/__init__.py does not contain  'dev' designator"; \
+	  fi \
+	else \
+	  $(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
+	    -v $(CURDIR):/workspace \
+	    --env BUILD_TYPE=local \
+	    python:3.11-alpine /bin/sh /workspace/ci/buildwheel.sh; \
+	fi
+
+clean:
+	-$(RM) netrc
+	-$(RM) pip.conf
+	-$(RM) cloudbuild_pypirc
+	-$(RM) -rf build
+	-$(RM) -rf  dist

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ run: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default
 	  python:$(PY_VERSION)-alpine \
 	  /bin/sh -c "/workspace/ci/runtests.sh onlysetup; exec /bin/sh"
 
+lint:
+	$(DOCKER) run --rm \
+	  -v $(CURDIR):/workspace \
+	  python:3.11-alpine sh -c "pip install flake8 && flake8 /workspace/gcloud_requests /workspace/tests"
+
 test: netrc pip.conf cloudbuild_pypirc ${HOME}/.config/gcloud/application_default_credentials.json
 	$(DOCKER) run -it --rm=true --name=$(PROJECT)_$@ \
 	  -v $(CURDIR):/workspace \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,35 @@ bucket = client.get_bucket("my-bucket")
 *Note*: This will run the tests against whatever GCP project you're
 currently logged into via the gcloud tool.
 
+# Running comprehensive tests
+
+req is a library that is released for multiple versions of python. When
+build in CI we run the tests against every version of python the library is
+supposed to work with.  This can be simulated in development by running the
+the tests inside docker containers.  The process is simplified by just
+running `make ci-tests`.  If you wanna run a test suite locally against a
+specific version of python only you can run `make PY_VERSION=3.11 test`.
+
+*Note*: This will run the tests against whatever GCP project `lp-infra-lab`.
+
+# Adding new python versions to supported roaster
+
+If you would like to add a new version of Python to the supported versions
+it must be handled in three locations:
+1. For local changes the variable `SUPPORTED_PY_VERSIONS' in the Makefile
+   must be adjusted to include (or exclude) the versions in question.
+2. in `ci/cloudbuild.yaml` steps need to be added (or removed) to address
+   the different versions of Python as well.
+3. in `ci/cloudbuild.yaml` the last step (build wheel and publish) shall use
+   the highest version of Python that is supported in the library.
+
+# Building a Pre-Release version
+
+Running `make bdist_wheel` will build the library instide a container and
+copy the results into `./build/` and `./dist/`.  It will not actually
+publish the wheel
+To Publish the wheel from the local setup, run `make BUILD_TYPE=release bdist_wheel`
+
 ## Authors
 
 `gcloud_requests` was authored at [Leadpages][leadpages].  You can

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ it must be handled in three locations:
    must be adjusted to include (or exclude) the versions in question.
 2. in `ci/cloudbuild.yaml` steps need to be added (or removed) to address
    the different versions of Python as well.
-3. in `ci/cloudbuild.yaml` the last step (build wheel and publish) shall use
-   the highest version of Python that is supported in the library.
+3. in `ci/cloudbuild.yaml`, update the `_LATEST_SUPPORTED_PY_VERSION` to the 
+   latest supporeted python version.
 
 # Building a Pre-Release version
 

--- a/ci/buildwheel.sh
+++ b/ci/buildwheel.sh
@@ -13,7 +13,7 @@ function setup_app() {
   cp -ar /workspace/tests                /app/tests
   # copy, don't link, because we change it with `sed`
   cp -v /workspace/requirements.txt     /app/requirements.txt
-  ln -s /workspace/requirements_dev.txt /app/requirements_dev.txt
+  ln -s /workspace/requirements-dev.txt /app/requirements-dev.txt
   ln -s /workspace/setup.cfg            /app/setup.cfg
   ln -s /workspace/setup.py             /app/setup.py
 }

--- a/ci/buildwheel.sh
+++ b/ci/buildwheel.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+function setup_root() {
+  mkdir /root/.pip && ln -s /workspace/pip.conf /root/.pip/pip.conf
+  ln -s /workspace/netrc                 /root/.netrc
+  ln -s /workspace/cloudbuild_pypirc     /root/.pypirc
+}
+
+function setup_app() {
+  mkdir /app && cd /app
+  # copy, because we wanna be able to toss out __pychache__ and *.pyc files
+  cp -ar /workspace/gcloud_requests      /app/gcloud_requests
+  cp -ar /workspace/tests                /app/tests
+  # copy, don't link, because we change it with `sed`
+  cp -v /workspace/requirements.txt     /app/requirements.txt
+  ln -s /workspace/requirements_dev.txt /app/requirements_dev.txt
+  ln -s /workspace/setup.cfg            /app/setup.cfg
+  ln -s /workspace/setup.py             /app/setup.py
+}
+
+function build_wheel() {
+  cd /app
+  export HOME=/root      # Damn you cloudbuild, presets to /home/builder/home ...
+  sed -i requirements.txt -e "s:^six$:six==1.15:"
+  pip install -r requirements.txt
+  pip install wheel
+
+  python setup.py bdist_wheel
+
+  ls -la build
+  ls -la dist
+  ls -la .
+}
+
+function upload_lib() {
+  # twine needs a compiler
+  cd /app
+  apk update && apk upgrade && apk add build-base libffi-dev
+  pip install twine
+  # "local" refers to the [local] section in pypirc which specifies the URL
+  echo "Uplaod library to Artifactory"
+  twine upload \
+    --repository local \
+    dist/* \
+    --config-file /root/.pypirc
+}
+
+function main() {
+  setup_root
+  setup_app
+  build_wheel
+  # additional safegard against uploading
+  if [ x"${BUILD_TYPE}" == x"release" ]; then
+    upload_lib
+  elif [ x"${BUILD_TYPE}" == x"local" ]; then
+    echo " copy into /workspace dir, which is a docker volume mount"
+    rm -rf  /workspace/{build,dist}
+    cp -avr /app/build /app/dist /workspace/
+  else
+    echo "Discard builded library!"
+  fi
+}
+
+main $@

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  _LATEST_SUPPORTED_PY_VERSION: 3.11
+
 steps:
   # Pulls down the netrc and pip conf files we need to access our private npm registry.
   # This file is stored within the context of this build, and becomes accessible to the CI image
@@ -22,7 +25,7 @@ steps:
         ls -la /workspace
         git log
 
-  - name: python:3.11-alpine
+  - name: python:${_LATEST_SUPPORTED_PY_VERSION}-alpine
     id: "Lint"
     entrypoint: sh
     args:
@@ -73,13 +76,13 @@ steps:
     args:
       - /workspace/ci/runtests.sh
 
-  - name: python:3.11-alpine
-    id: "Test: Inside Python-3.11"
+  - name: python:${_LATEST_SUPPORTED_PY_VERSION}-alpine
+    id: "Test: Inside Python-${_LATEST_SUPPORTED_PY_VERSION}"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
 
-  - name: python:3.11-alpine
+  - name: python:${_LATEST_SUPPORTED_PY_VERSION}-alpine
     id: "Build and Publish: create and upload library"
     entrypoint: sh
     env:

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -37,7 +37,6 @@ steps:
       - |
         # Create pip and auth dirs
         mkdir -p /root/.pip
-        mkdir -p /root
 
         # Link workspace configs into expected locations
         ln -sf /workspace/pip.conf /root/.pip/pip.conf

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -130,3 +130,7 @@ steps:
         else
           echo "_BUILD_TYPE is <$_BUILD_TYPE> -> DO NOT build a wheel publish."
         fi
+
+logsBucket: gs://leadpage-dev_cloudbuild/cloudbuild_logs
+options:
+  logging: GCS_ONLY

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -133,4 +133,5 @@ steps:
 
 logsBucket: gs://leadpage-dev_cloudbuild/cloudbuild_logs
 options:
+  machineType: 'E2_HIGHCPU_8' # We need these extra cores to run these unit tests for python 2, else it takes 20 minutes
   logging: GCS_ONLY

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -1,0 +1,73 @@
+steps:
+  # Pulls down the netrc and pip conf files we need to access our private npm registry.
+  # This file is stored within the context of this build, and becomes accessible to the CI image
+  # via a volume mount.
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    id: "Prepare: Copy over npm/pip/net config files from bucket"
+    entrypoint: "gsutil"
+    args:
+      - cp
+      - gs://center-builds/pypi/netrc
+      - gs://center-builds/pypi/pip.conf
+      - gs://center-builds/pypi/cloudbuild_pypirc
+      - .
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+    id: "Test the git checkout"
+    entrypoint: "bash"
+    args:
+      - -c
+      - |
+        ls -la /
+        ls -la /workspace
+        git log
+
+  - name: python:2.7-alpine
+    id: "Test: Inside Python-2.7"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.6-alpine
+    id: "Test: Inside Python-3.6"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.7-alpine
+    id: "Test: Inside Python-3.7"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.8-alpine
+    id: "Test: Inside Python-3.8"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.9-alpine
+    id: "Test: Inside Python-3.9"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.11-alpine
+    id: "Test: Inside Python-3.11"
+    entrypoint: sh
+    args:
+      - /workspace/ci/runtests.sh
+
+  - name: python:3.11-alpine
+    id: "Build and Publish: create and upload library"
+    entrypoint: sh
+    env:
+      - 'BUILD_TYPE=$_BUILD_TYPE'  # Safe-Guard inside buildwheel.sh
+    args:
+      - -c
+      - |
+        if [ x"$_BUILD_TYPE" == x"release" ]; then
+          /workspace/ci/buildwheel.sh
+        else
+          echo "_BUILD_TYPE is <$_BUILD_TYPE> -> DO NOT build a wheel publish."
+        fi

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _LATEST_SUPPORTED_PY_VERSION: 3.11
+  _LATEST_SUPPORTED_PY_VERSION: "3.11"
   _DATASTORE_PROJECT_ID: lp-infra-lab
   _DATASTORE_DATASET: lp-infra-lab
   _GOOGLE_CLOUD_PROJECT: lp-infra-lab

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -1,5 +1,9 @@
 substitutions:
   _LATEST_SUPPORTED_PY_VERSION: 3.11
+  _DATASTORE_PROJECT_ID: lp-infra-lab
+  _DATASTORE_DATASET: lp-infra-lab
+  _GOOGLE_CLOUD_PROJECT: lp-infra-lab
+  _GCLOUD_PROJECT: lp-infra-lab
 
 steps:
   # Pulls down the netrc and pip conf files we need to access our private npm registry.
@@ -46,41 +50,72 @@ steps:
         # Run linting
         flake8 gcloud_requests tests
 
-  - name: python:2.7-alpine
+  # We need to rebuild from source with alpine image, so for python 2.7, we dont use alpine
+  - name: python:2.7
     id: "Test: Inside Python-2.7"
-    entrypoint: sh
+    entrypoint: bash
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:3.6-alpine
     id: "Test: Inside Python-3.6"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:3.7-alpine
     id: "Test: Inside Python-3.7"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:3.8-alpine
     id: "Test: Inside Python-3.8"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:3.9-alpine
     id: "Test: Inside Python-3.9"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:${_LATEST_SUPPORTED_PY_VERSION}-alpine
     id: "Test: Inside Python-${_LATEST_SUPPORTED_PY_VERSION}"
     entrypoint: sh
     args:
       - /workspace/ci/runtests.sh
+    env:
+    - DATASTORE_PROJECT_ID=${_DATASTORE_PROJECT_ID}
+    - DATASTORE_DATASET=${_DATASTORE_DATASET}
+    - GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}
+    - GCLOUD_PROJECT=${_GCLOUD_PROJECT}
 
   - name: python:${_LATEST_SUPPORTED_PY_VERSION}-alpine
     id: "Build and Publish: create and upload library"

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -22,6 +22,27 @@ steps:
         ls -la /workspace
         git log
 
+  - name: python:3.11-alpine
+    id: "Lint"
+    entrypoint: sh
+    args:
+      - -c
+      - |
+        # Create pip and auth dirs
+        mkdir -p /root/.pip
+        mkdir -p /root
+
+        # Link workspace configs into expected locations
+        ln -sf /workspace/pip.conf /root/.pip/pip.conf
+        ln -sf /workspace/netrc /root/.netrc
+        ln -sf /workspace/cloudbuild_pypirc /root/.pypirc
+
+        # Install flake8 using the correct pip config
+        pip install flake8
+
+        # Run linting
+        flake8 gcloud_requests tests
+
   - name: python:2.7-alpine
     id: "Test: Inside Python-2.7"
     entrypoint: sh

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 function setup_root() {
   mkdir /root/.pip && ln -s /workspace/pip.conf /root/.pip/pip.conf
   ln -s /workspace/netrc                 /root/.netrc

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -9,10 +9,10 @@ function setup_root() {
 function setup_app() {
   mkdir /app && cd /app
   # copy, because we wanna be able to toss out __pychache__ and *.pyc files
-  cp -ar /workspace/gcloud_requests      /app/gcloud_requests
-  cp -ar /workspace/tests                /app/tests
-  # copy, don't link, because we changeit with `sed`
-  cp -v /workspace/requirements.txt     /app/requirements.txt
+  ln -s /workspace/gcloud_requests      /app/gcloud_requests
+  ln -s /workspace/tests                /app/tests
+
+  ln -s /workspace/requirements.txt     /app/requirements.txt
   ln -s /workspace/requirements-dev.txt /app/requirements-dev.txt
   ln -s /workspace/setup.cfg            /app/setup.cfg
   ln -s /workspace/setup.py             /app/setup.py

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -13,33 +13,32 @@ function setup_app() {
   cp -ar /workspace/tests                /app/tests
   # copy, don't link, because we changeit with `sed`
   cp -v /workspace/requirements.txt     /app/requirements.txt
-  ln -s /workspace/requirements_dev.txt /app/requirements_dev.txt
+  ln -s /workspace/requirements-dev.txt /app/requirements-dev.txt
   ln -s /workspace/setup.cfg            /app/setup.cfg
   ln -s /workspace/setup.py             /app/setup.py
 }
 
-function run_tests() {
+function setup_env() {
   cd /app
-
-  # Runtime with venv -> 3m:23s, without venv -> 2m:43s
   # this is a throwaway container, venv not needed!
-  #pip install virtualenv
-  #virtualenv .venv
-  #. .venv/bin/activate
 
-  export HOME=/root      # this is a cloudbuild problem!!!!
-
-  sed -i requirements.txt -e "s:^six$:six==1.15:"
   ls -la
-  cat requirements.txt requirements_dev.txt
-  pip install -r requirements_dev.txt
-  py.test tests
+  cat requirements.txt requirements-dev.txt
+  pip install -r requirements-dev.txt
 }
 
 function main() {
+  local onlysetup=$1
+  export HOME=/root      # this is a cloudbuild problem!!!!
   setup_root
   setup_app
-  run_tests
+  setup_env
+  if [ x"${onlysetup}" != x"onlysetup" ]; then
+    echo "RUNNING TESTS: onlysetup=<${onlysetup}>"
+    py.test -sv tests
+  else
+    echo "ONLY PREPARE ENV: onlysetup=<${onlysetup}>"
+  fi
 }
 
 main $@

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+function setup_root() {
+  mkdir /root/.pip && ln -s /workspace/pip.conf /root/.pip/pip.conf
+  ln -s /workspace/netrc                 /root/.netrc
+  ln -s /workspace/cloudbuild_pypirc     /root/.pypirc
+}
+
+function setup_app() {
+  mkdir /app && cd /app
+  # copy, because we wanna be able to toss out __pychache__ and *.pyc files
+  cp -ar /workspace/gcloud_requests      /app/gcloud_requests
+  cp -ar /workspace/tests                /app/tests
+  # copy, don't link, because we changeit with `sed`
+  cp -v /workspace/requirements.txt     /app/requirements.txt
+  ln -s /workspace/requirements_dev.txt /app/requirements_dev.txt
+  ln -s /workspace/setup.cfg            /app/setup.cfg
+  ln -s /workspace/setup.py             /app/setup.py
+}
+
+function run_tests() {
+  cd /app
+
+  # Runtime with venv -> 3m:23s, without venv -> 2m:43s
+  # this is a throwaway container, venv not needed!
+  #pip install virtualenv
+  #virtualenv .venv
+  #. .venv/bin/activate
+
+  export HOME=/root      # this is a cloudbuild problem!!!!
+
+  sed -i requirements.txt -e "s:^six$:six==1.15:"
+  ls -la
+  cat requirements.txt requirements_dev.txt
+  pip install -r requirements_dev.txt
+  py.test tests
+}
+
+function main() {
+  setup_root
+  setup_app
+  run_tests
+}
+
+main $@

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 function setup_root() {
   mkdir /root/.pip && ln -s /workspace/pip.conf /root/.pip/pip.conf
   ln -s /workspace/netrc                 /root/.netrc

--- a/gcloud_requests/__init__.py
+++ b/gcloud_requests/__init__.py
@@ -4,4 +4,4 @@ from .datastore import DatastoreRequestsProxy, enter_transaction, exit_transacti
 from .pubsub import PubSubRequestsProxy  # noqa
 from .storage import CloudStorageRequestsProxy  # noqa
 
-__version__ = "2.0.4-dev"
+__version__ = "2.0.4"

--- a/gcloud_requests/__init__.py
+++ b/gcloud_requests/__init__.py
@@ -4,4 +4,4 @@ from .datastore import DatastoreRequestsProxy, enter_transaction, exit_transacti
 from .pubsub import PubSubRequestsProxy  # noqa
 from .storage import CloudStorageRequestsProxy  # noqa
 
-__version__ = "2.0.4"
+__version__ = "2.0.4-dev"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ google-cloud-datastore>=1.6,<2.0
 google-cloud-storage>=1.1.1,<2.0
 
 # Testing
-futures
+futures; python_version < "3"
 httmock
 mock
 pytest>=3

--- a/tests/test_datastore_proxy.py
+++ b/tests/test_datastore_proxy.py
@@ -170,7 +170,13 @@ def test_datastore_proxy_retries_token_refresh_errors(datastore_proxy):
     # RefreshError to be raised
     refresh_calls = []
 
-    @urlmatch(netloc=r"^(oauth2\.googleapis\.com|accounts\.google\.com)$", path=r"^/(o/oauth2/token|token)$")
+    # Match BOTH:
+    #  - OAuth2 token endpoints (local/docker)
+    #  - GCE metadata token endpoint (Cloud Build / GCE)
+    @urlmatch(
+        netloc=r"^(oauth2\.googleapis\.com|accounts\.google\.com|metadata\.google\.internal)$",
+        path=r".*token.*",
+    )
     def refresh(netloc, request):
         refresh_calls.append(1)
         if sum(refresh_calls) == 1:


### PR DESCRIPTION
- Added Cloud Build pipeline for deployment/publishing
- Added Makefile to help developers
- Added README points to explain local development and cloud build pipeline
- Updated `tests/test_datastore_proxy.py` to have `refresh` (token) have `@urlmatch` for both - OAuth2 token endpoints (local/docker) - AND  - GCE metadata token endpoint (Cloud Build / GCE)
- Pinned `futures` to only be installed for `python < 3`
- Removed Jenkinsfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloud Build Pipeline for deployment/Publishing

* **Documentation**
  * Added comprehensive testing and contribution guidelines to README.

* **Chores**
  * Enhanced build and testing infrastructure.
  * Expanded test coverage across Local and Cloud Environments and Python Versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->